### PR TITLE
I2C Shared Bus Compatiblity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "sh8601-rs"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "critical-section",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ waveshare_18_amoled = [
   "dep:esp-println",
   "dep:critical-section",
   "dep:esp-bootloader-esp-idf",
-  "esp-println/jtag-serial",
+  "esp-println/auto",
 ]
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "sh8601-rs"
-version = "0.1.5"
+version = "0.1.6"
 description = "A Rust driver for the SH8601 display controller"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/theembeddedrustacean/sh8601-rs"

--- a/src/displays/waveshare_18_amoled.rs
+++ b/src/displays/waveshare_18_amoled.rs
@@ -4,10 +4,8 @@
 use crate::{ControllerInterface, ResetInterface};
 use esp_hal::{
     delay::Delay,
-    i2c::master::{Error as I2cError, I2c},
-    spi::master::DataMode,
     spi::{
-        master::{Address, Command, SpiDmaBus},
+        master::{Address, Command, SpiDmaBus, DataMode},
         Error as SpiError,
     },
     Blocking,
@@ -89,18 +87,21 @@ impl ControllerInterface for Ws18AmoledDriver {
 }
 
 /// I2C-controlled GPIO Reset Pin
-pub struct ResetDriver {
-    i2c: I2c<'static, Blocking>,
+pub struct ResetDriver<I2C> {
+    i2c: I2C,
 }
 
-impl ResetDriver {
-    pub fn new(i2c: I2c<'static, Blocking>) -> Self {
+impl<I2C> ResetDriver<I2C> {
+    pub fn new(i2c: I2C) -> Self {
         ResetDriver { i2c }
     }
 }
 
-impl ResetInterface for ResetDriver {
-    type Error = I2cError;
+impl<I2C> ResetInterface for ResetDriver<I2C>
+where
+    I2C: embedded_hal::i2c::I2c,
+{
+    type Error = I2C::Error;
 
     fn reset(&mut self) -> Result<(), Self::Error> {
         let delay = Delay::new();

--- a/src/displays/waveshare_18_amoled.rs
+++ b/src/displays/waveshare_18_amoled.rs
@@ -5,7 +5,7 @@ use crate::{ControllerInterface, ResetInterface};
 use esp_hal::{
     delay::Delay,
     spi::{
-        master::{Address, Command, SpiDmaBus, DataMode},
+        master::{Address, Command, DataMode, SpiDmaBus},
         Error as SpiError,
     },
     Blocking,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! for controlling the SH8601 display controller.
 //! Different displays can be supported by implementing the `ControllerInterface` and `ResetInterface` traits.
 //! This is because the SH8601 is used in different displays with various controller interfaces such as SPI or QSPI.
-//! Addittionally, the reset pin is controlled via GPIO or I2C GPIO expander.
+//! Additionally, the reset pin is controlled via GPIO or I2C GPIO expander.
 //!
 //! The driver currently incorporates support the Waveshare 1.8" AMOLED display out of the box, but can be extended to support other displays using the SH8601 controller.
 //!


### PR DESCRIPTION
Required for Slint integration, because Touch and Display is on shared the same I2C Bus.