### PR TITLE
perf: implement optimized clear

### DIFF
--- a/src/graphics_core.rs
+++ b/src/graphics_core.rs
@@ -40,6 +40,29 @@ where
         }
         Ok(())
     }
+
+    /// Optimized clear - fill entire framebuffer
+    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        let c = color.into_storage();
+        let r = (c >> 16) as u8;
+        let g = (c >> 8) as u8;
+        let b = c as u8;
+
+        // Fast path for uniform colors (black, white, grayscale)
+        if r == g && r == b {
+            self.framebuffer.fill(r);
+
+            return Ok(());
+        }
+
+        for chunk in self.framebuffer.chunks_exact_mut(3) {
+            chunk[0] = r;
+            chunk[1] = g;
+            chunk[2] = b;
+        }
+
+        Ok(())
+    }
 }
 
 // =========== embedded-graphics OriginDimensions Implementation ===========


### PR DESCRIPTION
I have a few screens that do a full screen clear to black, the DrawTarget default implementations all fallback to `draw_iter()` which is doing much more than necessary for a simple clear.

This reduces draw time of a full clear in my cases from ~140ms down to ~45ms.