### PR TITLE
feat: add vendor-specific init commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ target/
 # Mac Artifacts
 .DS_Store
 
+.env
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/examples/ws_143in_tch_amoled.rs
+++ b/examples/ws_143in_tch_amoled.rs
@@ -87,6 +87,10 @@ fn main() -> ! {
     // Initialize display driver for the Waveshare 1.8" AMOLED display
     let ws_driver = Ws143TouchAmoledDriver::new(lcd_spi);
 
+    // Some Waveshare 1.43 displays use a different LCD driver (CO5300 instead of SH8601)
+    // which have a different init sequence but still work with this driver
+    // let ws_driver = ws_driver.use_co5300_init_cmds();
+
     // Set up the display size
     const DISPLAY_SIZE: DisplaySize = DisplaySize::new(466, 466);
 

--- a/src/displays/waveshare_143_tch_amoled.rs
+++ b/src/displays/waveshare_143_tch_amoled.rs
@@ -20,11 +20,24 @@ pub const DMA_CHUNK_SIZE: usize = 16380;
 /// QSPI implementation of ControllerInterface for SH8601
 pub struct Ws143TouchAmoledDriver {
     pub qspi: SpiDmaBus<'static, Blocking>,
+    pub use_co5300_init_cmds: bool,
 }
 
 impl Ws143TouchAmoledDriver {
     pub fn new(qspi: SpiDmaBus<'static, Blocking>) -> Self {
-        Ws143TouchAmoledDriver { qspi }
+        Ws143TouchAmoledDriver {
+            qspi,
+            use_co5300_init_cmds: false,
+        }
+    }
+
+    /// Seems like some waveshare 1.43 have a different lcd driver (co5300 instead of sh8601)
+    /// which have a different init sequence but still work with this driver
+    pub fn use_co5300_init_cmds(self) -> Self {
+        Self {
+            use_co5300_init_cmds: true,
+            ..self
+        }
     }
 }
 
@@ -85,35 +98,31 @@ impl ControllerInterface for Ws143TouchAmoledDriver {
         Ok(())
     }
 
-    // seems like some waveshare 1.43in have a different lcd driver (co5300 instead of sh8601)
-    // which have a different init sequence but still work with this driver
-
-    // co5300 init sequence
-    fn vendor_specific_init_commands() -> &'static [(u8, &'static [u8], u32)] {
-        &[
-            (commands::SLPOUT, &[], 120),
-            (commands::SPI_MODE, &[0x80], 0),
-            (commands::WRCTRLD1, &[0x20], 1),
-            (commands::HBM_WRDISBV1, &[0xFF], 1),
-            (commands::WRDISBV, &[0x00], 1),
-            (commands::SLPOUT, &[0x00], 10),
-            (commands::WRDISBV, &[0xFF], 0),
-            //
-        ]
+    fn vendor_specific_init_commands(&self) -> &'static [(u8, &'static [u8], u32)] {
+        if self.use_co5300_init_cmds {
+            // co5300 init sequence
+            &[
+                (commands::SLPOUT, &[], 120),
+                (commands::SPI_MODE, &[0x80], 0),
+                (commands::WRCTRLD1, &[0x20], 1),
+                (commands::HBM_WRDISBV1, &[0xFF], 1),
+                (commands::WRDISBV, &[0x00], 1),
+                (commands::SLPOUT, &[0x00], 10),
+                (commands::WRDISBV, &[0xFF], 0),
+            ]
+        } else {
+            // sh8601 init sequence
+            &[
+                (commands::SLPOUT, &[], 120),
+                (commands::TESCAN, &[0x01, 0xD1], 0),
+                (commands::TEON, &[0x00], 0),
+                (commands::WRCTRLD1, &[0x20], 10),
+                (commands::WRDISBV, &[0x00], 10),
+                (commands::SLPOUT, &[0x00], 10),
+                (commands::WRDISBV, &[0xFF], 0),
+            ]
+        }
     }
-
-    // sh8601 init sequence
-    //fn vendor_specific_init_commands() -> &'static [(u8, &'static [u8], u32)] {
-    //    &[
-    //        (commands::SLPOUT, &[], 120),
-    //        (commands::TESCAN, &[0x01, 0xD1], 0),
-    //        (commands::TEON, &[0x00], 0),
-    //        (commands::WRCTRLD1, &[0x20], 10),
-    //        (commands::WRDISBV, &[0x00], 10),
-    //        (commands::SLPOUT, &[0x00], 10),
-    //        (commands::WRDISBV, &[0xFF], 0),
-    //    ]
-    //}
 }
 
 /// I2C-controlled GPIO Reset Pin

--- a/src/displays/waveshare_18_amoled.rs
+++ b/src/displays/waveshare_18_amoled.rs
@@ -85,7 +85,7 @@ impl ControllerInterface for Ws18AmoledDriver {
         Ok(())
     }
 
-    fn vendor_specific_init_commands() -> &'static [(u8, &'static [u8], u32)] {
+    fn vendor_specific_init_commands(&self) -> &'static [(u8, &'static [u8], u32)] {
         &[
             (commands::SLPOUT, &[], 120),
             (commands::TESCAN, &[0x01, 0xC5], 0),

--- a/src/displays/waveshare_18_amoled.rs
+++ b/src/displays/waveshare_18_amoled.rs
@@ -1,7 +1,7 @@
 //! Driver implementation for Waveshare ESP32-S3 1.8" AMOLED
 //! Uses QSPI interface and I2C-based GPIO expander or GPIO for reset.
 
-use crate::{ControllerInterface, ResetInterface};
+use crate::{ControllerInterface, ResetInterface, commands};
 use esp_hal::{
     Blocking,
     delay::Delay,
@@ -83,6 +83,16 @@ impl ControllerInterface for Ws18AmoledDriver {
             }
         }
         Ok(())
+    }
+
+    fn vendor_specific_init_commands() -> &'static [(u8, &'static [u8], u32)] {
+        &[
+            (commands::SLPOUT, &[], 120),
+            (commands::TESCAN, &[0x01, 0xC5], 0),
+            (commands::TEON, &[0x00], 0),
+            (commands::DISPON, &[], 120),
+            (commands::PTLAR, &[0x00, 0x80, 0x00, 0x02], 10),
+        ]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub trait ControllerInterface {
 
     /// vendor specific initialization commands.
     /// [(command, data, delay_ms)]
-    fn vendor_specific_init_commands() -> &'static [(u8, &'static [u8], u32)] {
+    fn vendor_specific_init_commands(&self) -> &'static [(u8, &'static [u8], u32)] {
         &[
             (commands::TESCAN, &[0x01, 0xD1], 0),
             (commands::TEON, &[0x00], 0),
@@ -319,7 +319,7 @@ where
     where
         DELAY: DelayNs,
     {
-        for (command, data, delay_ms) in IFACE::vendor_specific_init_commands() {
+        for (command, data, delay_ms) in IFACE::vendor_specific_init_commands(&self.interface) {
             self.send_command_with_data(*command, data)?;
             delay.delay_ms(*delay_ms);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@
 //!
 
 #![no_std]
-pub mod displays;
 
 #[cfg(feature = "waveshare_18_amoled")]
 pub use displays::waveshare_18_amoled::*;


### PR DESCRIPTION
Some Waveshare 1.43 (like the one I have) use a CO5300 instead of a SH8601 which needs a different initialization sequence.
To fix this, I added a function to define a vendor specific init command sequence to the `ControllerInterface` trait. The default and vendor specific values are based on the provided Waveshare demo project.